### PR TITLE
set text_offset to MINOS_TEXT_OFFSET if defined

### DIFF
--- a/arch/aarch64/core/boot.S
+++ b/arch/aarch64/core/boot.S
@@ -31,7 +31,11 @@ _start:
 	/* interrupt disabled mmu/dcache/icache off */
 	msr	daifset, #2
 	b	do_start
+#ifdef CONFIG_MINOS_TEXT_OFFSET
+	.quad   CONFIG_MINOS_TEXT_OFFSET	     /* Image load offset from start of RAM */
+#else
 	.quad   CONFIG_MINOS_ENTRY_ADDRESS	     /* Image load offset from start of RAM */
+#endif
         .quad   __code_end - _start		     /* reserved */
         .quad   0				     /* reserved */
         .quad   0				     /* reserved */


### PR DESCRIPTION
Image is placed text_offset bytes from 2MB aligned base near the start of usable system RAM [1].

MINOS_TEXT_OFFSET and MINOS_ENTRY_ADDRESS may not be equal.

[1]: https://github.com/u-boot/u-boot/blob/v2020.10/arch/arm/lib/image.c#L72-L74