### PR TITLE
check 'argc' before accessing 'argv'

### DIFF
--- a/apps/esh/shell.c
+++ b/apps/esh/shell.c
@@ -48,7 +48,7 @@ static void shell_detach_tty(void)
 
 static int shell_cmd_tty(int argc, char **argv)
 {
-	if (strcmp(argv[1], "attach") == 0) {
+	if (argc > 2 && strcmp(argv[1], "attach") == 0) {
 		printf("Attach tty: %s press any key to active the console\n",
 				argv[2]);
 		pesh->tty = open_tty(argv[2]);

--- a/virt/vm.c
+++ b/virt/vm.c
@@ -1278,7 +1278,7 @@ static int vm_command_hdl(int argc, char **argv)
 {
 	uint32_t vmid;
 
-	if ((strcmp(argv[1], "start") == 0) && (argc > 2)) {
+	if (argc > 2 && strcmp(argv[1], "start") == 0) {
 		vmid = atoi(argv[2]);
 		if (vmid == 0xff)
 			start_all_vm();


### PR DESCRIPTION
When only 'tty' or 'vm' is entered in the shell, the system hangs.