### PR TITLE
Change the detach key from Ctrl-D to Ctrl-]

### DIFF
--- a/apps/esh/shell.c
+++ b/apps/esh/shell.c
@@ -89,7 +89,7 @@ int shell_task(void *data)
 				break;
 
 			if (pesh->tty) {
-				if (ch == 4)	/*  ctrl + D */ {
+				if (ch == 29) { // Ctrl-]
 					shell_detach_tty();
 					esh_rx(pesh, '\n');
 				} else {


### PR DESCRIPTION
<kbd>Ctrl</kbd> + <kbd>D</kbd>, meaning `EOF`, is widely used in many terminal programs. While <kbd>Ctrl</kbd> + <kbd>]</kbd> is used to detach from the virtual console in `Xen`.