### PR TITLE
mvm: fix the load address of dtb

### DIFF
--- a/tools/mvm/os/os_linux.c
+++ b/tools/mvm/os/os_linux.c
@@ -480,7 +480,7 @@ static int linux_load_images(struct vm *vm)
 		return -EIO;
 	}
 
-	ret = load_spare_image(vm->dfd, base + 0x3e00000);
+	ret = load_spare_image(vm->dfd, base + vm->setup_data - vm->mem_start);
 	if (ret) {
 		pr_err("read dtb image failed\n");
 		return -EIO;


### PR DESCRIPTION
The DTB address when loaded [1] is inconsistent with the DTB address when used [2], unless mem_size is 32M.

[1]: https://github.com/minosproject/minos/blob/7a209b7766681846be57319661f814b418bb5159/tools/mvm/os/os_linux.c#L483
[2]: https://github.com/minosproject/minos/blob/7a209b7766681846be57319661f814b418bb5159/tools/mvm/os/os_linux.c#L323