### PR TITLE
use strncmp when reading files from ramdisk

### DIFF
--- a/core/ramdisk.c
+++ b/core/ramdisk.c
@@ -55,7 +55,7 @@ static struct ramdisk_inode *get_file_inode(const char *name)
 	struct ramdisk_inode *inode;
 
 	for (inode = root; inode < root + sb->file_cnt; inode++) {
-		if (strcmp(inode->fname, name) == 0)
+		if (strncmp(inode->fname, name, RAMDISK_FNAME_SIZE - 1) == 0)
 			return inode;
 	}
 

--- a/include/minos/of.h
+++ b/include/minos/of.h
@@ -150,6 +150,4 @@ int get_device_irq_index(struct device_node *node, uint32_t *irq,
 int of_get_console_name(void *dtb, char **name);
 int of_init_bootargs(void);
 
-int of_get_ramdisk(void);
-
 #endif

--- a/scripts/make_ramdisk.sh
+++ b/scripts/make_ramdisk.sh
@@ -36,7 +36,7 @@ encode_number() {
 
 # ${1}: file
 pack_file() {
-    printf "%s" $(basename ${1}) |
+    printf "%.*s\0" $((FNAME_SIZE - 1)) $(basename ${1}) |
         dd conv=notrunc obs=${off1} of=${image} seek=1 2> /dev/null
 
     local size=$(stat -c "%s" ${1})
@@ -64,7 +64,7 @@ make_ramdisk() {
 
     local file
     for file in ${files[@]}; do
-        printf "Packing %.*s\n" ${FNAME_SIZE} $(basename ${file})
+        printf "Packing %.*s\n" $((FNAME_SIZE - 1)) $(basename ${file})
         pack_file ${file}
     done
 


### PR DESCRIPTION
strncmp is safer than strcmp. Besides, make sure the file name ends with "\0".