### PR TITLE
correctly emulate the zero register

### DIFF
--- a/arch/aarch64/include/asm/arch.h
+++ b/arch/aarch64/include/asm/arch.h
@@ -44,11 +44,18 @@
 #define stack_to_gp_regs(base) \
 	(gp_regs *)(base - sizeof(gp_regs))
 
-#define get_reg_value(regs, index)	\
-	*((unsigned long *)(regs) + index + 3)
+static inline u64 get_reg_value(gp_regs *regs, int index)
+{
+	return (index == 31) ? 0 : *(&regs->x0 + index);
+}
 
-#define set_reg_value(regs, index, value)	\
-	*((unsigned long *)(regs) + index + 3) = (unsigned long)value
+static inline void set_reg_value(gp_regs *regs, int index, u64 value)
+{
+	if (index == 31)
+		return;
+
+	*(&regs->x0 + index) = value;
+}
 
 #define read_sysreg32(name) ({						\
 	uint32_t _r;							\


### PR DESCRIPTION
In a general-purpose register field the value 31 represents either the current stack pointer or the zero register, depending on the instruction and the operand position.

Inspired by https://github.com/xen-project/xen/commit/1d8279231ff8781c013dd1b909edda22f7b57720