### PR TITLE
mvm: add option to disable WFI trap

### DIFF
--- a/tools/mvm/main/option.c
+++ b/tools/mvm/main/option.c
@@ -58,6 +58,7 @@ DECLARE_VM_OPTION(setup_mem_base);
 DECLARE_VM_OPTION(type);
 DECLARE_VM_OPTION(cmdline);
 DECLARE_VM_OPTION(gic);
+DECLARE_VM_OPTION(wfi);
 
 DECLARE_VDEV_OPTION(device);
 
@@ -77,6 +78,7 @@ static struct mvm_option_parser *vm_parser_table[] = {
 	VM_OP(type),
 	VM_OP(cmdline),
 	VM_OP(gic),
+	VM_OP(wfi),
 };
 
 static struct mvm_option_parser *os_parser_table[] = {

--- a/tools/mvm/main/option_vm.c
+++ b/tools/mvm/main/option_vm.c
@@ -203,6 +203,16 @@ static int setup_vm_gic(char *arg, char *sub_arg, void *data)
 	return 0;
 }
 
+static int setup_vm_wfi(char *arg, char *sub_arg, void *data)
+{
+	struct vm *vm = data;
+
+	pr_info("disable WFI trap\n");
+	vm->flags |= VM_FLAGS_NATIVE_WFI;
+
+	return 0;
+}
+
 DEFINE_OPTION_VM(mem_size, "memory", 1, setup_vm_mem_size);
 DEFINE_OPTION_VM(name, "vm_name", 0, setup_vm_name);
 DEFINE_OPTION_VM(os_type, "vm_os", 1, setup_vm_os_type);
@@ -219,3 +229,4 @@ DEFINE_OPTION_VM(setup_mem_base,
 DEFINE_OPTION_VM(type, "os-64bit", 0, setup_vm_type);
 DEFINE_OPTION_VM(cmdline, "cmdline", 0, setup_vm_cmdline);
 DEFINE_OPTION_VM(gic, "gic", 0, setup_vm_gic);
+DEFINE_OPTION_VM(wfi, "native_wfi", 0, setup_vm_wfi);


### PR DESCRIPTION
Without this option, the task status of the secondary vcpu(s) will be set to `TASK_STAT_SUSPEND` by `wfi_wfe_handler`. So there will be the following errors:

    WRN wrong task state in cpu new list
    ERR percpu_task_ready: wrong task state 0

This will cause the guest VM to have only one CPU core.