### PR TITLE
add IOMMU subsystem

### DIFF
--- a/arch/aarch64/lds/minos.lds.S
+++ b/arch/aarch64/lds/minos.lds.S
@@ -79,6 +79,14 @@ SECTIONS
 
 	. = ALIGN(8);
 
+	__iommu_ops_start = .;
+	.__iommu_ops : {
+		*(.__iommu_ops)
+	}
+	__iommu_ops_end = .;
+
+	. = ALIGN(8);
+
 	__virqchip_start = .;
 	.__virqchip : {
 		*(.__virqchip)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,6 +1,7 @@
 menu "Device Drivers"
 
 source "drivers/irq-chips/Kconfig"
+source "drivers/iommu/Kconfig"
 source "drivers/serial/Kconfig"
 source "drivers/device-tree/Kconfig"
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,5 +1,6 @@
 obj-$(CONFIG_SERIAL) 		+= serial/
 obj-y 				+= irq-chips/
+obj-$(CONFIG_IOMMU)		+= iommu/
 obj-$(CONFIG_DEVICE_TREE) 	+= device-tree/
 obj-y 				+= device_id.o
 obj-y				+= tty.o

--- a/drivers/iommu/Kconfig
+++ b/drivers/iommu/Kconfig
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+
+if VIRT
+
+menu "IOMMU drivers"
+
+config IOMMU
+	def_bool y
+
+endmenu
+
+endif
+
+comment "IOMMU drivers need virtualization support"
+	depends on !VIRT

--- a/include/minos/device_id.h
+++ b/include/minos/device_id.h
@@ -22,6 +22,11 @@ typedef enum __device_class {
 #define DEVICE_NODE_F_ROOT		(1 << 0)
 #define DEVICE_NODE_F_OF		(1 << 1)
 
+struct node_iommu {
+	/* private information for iommu drivers */
+	void *priv;
+};
+
 /*
  * data       - the data for all device such as dtb or acpi
  * offset     - node offset
@@ -30,6 +35,7 @@ typedef enum __device_class {
  * parent     - the parent node of device_node
  * child      - child nodes of the device_node
  * sibling    - brother of the device node
+ * iommu      - information for iommu
  */
 struct device_node {
 	void *data;
@@ -42,6 +48,7 @@ struct device_node {
 	struct device_node *next;
 	device_class_t class;
 	unsigned long flags;
+	struct node_iommu iommu;
 };
 
 #define devnode_name(node)	node->name
@@ -65,6 +72,13 @@ struct module_id {
 	module_match_##mname __section(.__irqchip) = { \
 		.comp = mn, \
 		.data = irqchip, \
+	}
+
+#define IOMMU_OPS_DECLARE(mname, mn, iommu_ops) \
+	static const struct module_id __used \
+	module_match_##mname __section(.__iommu_ops) = { \
+		.comp = mn, \
+		.data = iommu_ops, \
 	}
 
 #define VIRQCHIP_DECLARE(mname, mn, virqchip) \

--- a/include/virt/iommu.h
+++ b/include/virt/iommu.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef _MINOS_IOMMU_H_
+#define _MINOS_IOMMU_H_
+
+struct iommu_ops {
+	int (*init)(struct device_node *node);
+	int (*vm_init)(struct vm *vm);
+	int (*vm_destroy)(struct vm *vm);
+	int (*iotlb_flush_all)(struct vm *vm);
+	int (*assign_node)(struct vm *vm, struct device_node *node);
+	int (*deassign_node)(struct vm *vm, struct device_node *node);
+};
+
+int iommu_vm_init(struct vm *vm);
+
+int iommu_vm_destroy(struct vm *vm);
+
+int iommu_iotlb_flush_all(struct vm *vm);
+
+int iommu_assign_node(struct vm *vm, struct device_node *node);
+
+int iommu_deassign_node(struct vm *vm, struct device_node *node);
+
+#endif

--- a/include/virt/vm.h
+++ b/include/virt/vm.h
@@ -62,6 +62,16 @@ struct vcpu {
 	void **context;
 } __align_cache_line;
 
+struct vm_iommu {
+	/* private information for iommu drivers */
+	void *priv;
+
+	const struct iommu_ops *ops;
+
+	/* list of device nodes assigned to this vm */
+	struct list_head nodes;
+};
+
 struct vm {
 	int vmid;
 	uint32_t vcpu_nr;
@@ -101,6 +111,8 @@ struct vm {
 	void *os_data;
 
 	void *arch_data;
+
+	struct vm_iommu iommu;
 } __align(sizeof(unsigned long));
 
 #define vm_name(vm)	devnode_name(vm->dev_node)

--- a/virt/Makefile
+++ b/virt/Makefile
@@ -14,3 +14,4 @@ obj-$(CONFIG_VWDT_SP805)	+= vwdt.o
 obj-y				+= varm_timer.o
 obj-y				+= debug_console.o
 obj-y				+= vmodule.o
+obj-$(CONFIG_IOMMU)		+= iommu.o

--- a/virt/iommu.c
+++ b/virt/iommu.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <minos/errno.h>
+#include <minos/of.h>
+#include <virt/vm.h>
+#include <virt/iommu.h>
+
+static const struct iommu_ops *iommu_ops;
+
+int iommu_vm_init(struct vm *vm)
+{
+	struct vm_iommu *iommu = &vm->iommu;
+	int ret;
+
+	init_list(&iommu->nodes);
+
+	iommu->ops = iommu_ops;
+
+	if (!iommu->ops || !iommu->ops->vm_init)
+		return 0;
+
+	ret = iommu->ops->vm_init(vm);
+
+	return ret;
+}
+
+int iommu_iotlb_flush_all(struct vm *vm)
+{
+	struct vm_iommu *iommu = &vm->iommu;
+	int ret;
+
+	if (!iommu->ops || !iommu->ops->iotlb_flush_all)
+		return 0;
+
+	/* TODO: need to hold mm_lock? */
+	ret = iommu->ops->iotlb_flush_all(vm);
+	if (ret)
+		pr_err("vm%d: IOMMU IOTLB flush all failed: %d\n", vm_id(vm),
+		       ret);
+
+	return ret;
+}
+
+int iommu_assign_node(struct vm *vm, struct device_node *node)
+{
+	struct vm_iommu *iommu = &vm->iommu;
+	int ret;
+	char name[32];
+	struct device_node *stub_node;
+
+	ret = of_get_string(node, "minos,stub-node", name, ARRAY_SIZE(name));
+	if (ret <= 0)
+		return 0;
+
+	stub_node = of_find_node_by_name(hv_node, name);
+	if (!stub_node)
+		return -ENOENT;
+
+	if (!iommu->ops || !iommu->ops->assign_node)
+		return 0;
+
+	pr_info("[VM%d NODE] %s <- %s\n", vm_id(vm), devnode_name(stub_node),
+		devnode_name(node));
+
+	ret = iommu->ops->assign_node(vm, stub_node);
+
+	return ret;
+}
+
+static void *iommu_ops_init(struct device_node *node, void *arg)
+{
+	extern unsigned char __iommu_ops_start;
+	extern unsigned char __iommu_ops_end;
+	void *s, *e;
+	struct iommu_ops *ops;
+
+	s = (void *)&__iommu_ops_start;
+	e = (void *)&__iommu_ops_end;
+
+	ops = (struct iommu_ops *)of_device_node_match(node, s, e);
+	if (!ops)
+		return NULL;
+
+	/*
+	 * Some platforms have tree-like IOMMUs, so this function may be
+	 * called multiple times.
+	 */
+	if (!iommu_ops)
+		iommu_ops = ops;
+	else if (iommu_ops != ops)
+		pr_warn("Cannot set IOMMU ops, already set to a different value\n");
+
+	if (ops->init)
+		ops->init(node);
+
+	return node;
+}
+
+static void of_iommu_init(void)
+{
+	of_iterate_all_node_loop(hv_node, iommu_ops_init, NULL);
+}
+
+static int iommu_init(void)
+{
+#ifdef CONFIG_DEVICE_TREE
+	of_iommu_init();
+#endif
+
+	return 0;
+}
+
+subsys_initcall(iommu_init);

--- a/virt/resource.c
+++ b/virt/resource.c
@@ -25,6 +25,7 @@
 #include <minos/irq.h>
 #include <virt/vmbox.h>
 #include <minos/platform.h>
+#include <virt/iommu.h>
 
 static void *virqchip_start;
 static void *virqchip_end;
@@ -252,9 +253,10 @@ static int create_vm_pdev_of(struct vm *vm, struct device_node *node)
 
 	ret += create_pdev_iomem_of(vm, node);
 	ret += create_pdev_virq_of(vm, node);
+	ret += iommu_assign_node(vm, node);
 
 	if (ret)
-		pr_notice("create %s fail\n", node->name);
+		pr_err("create %s fail\n", node->name);
 
 	return ret;
 }

--- a/virt/vm.c
+++ b/virt/vm.c
@@ -36,6 +36,7 @@
 #include <minos/shell_command.h>
 #include <virt/virt.h>
 #include <minos/ramdisk.h>
+#include <virt/iommu.h>
 
 extern void virqs_init(void);
 extern int vmodules_init(void);
@@ -1094,6 +1095,8 @@ struct vm *create_vm(struct vmtag *vme)
 
 	if (native)
 		vm->flags |= VM_FLAGS_NATIVE;
+
+	iommu_vm_init(vm);
 
 	vm_mm_struct_init(vm);
 


### PR DESCRIPTION
This subsystem is used to pass through a DMA device to a guest VM.

To pass through a DMA device, the following steps are required:

- add the device node to the guest VM dts
- add a correct `virq_affinity` property to the device node
- create a stub node in Minos dts
- move the `iommus` property from the device node of guest VM to the stub
  node of Minos
- add a `minos,stub-node` property to the device node of guest VM and set
  it as the name of the stub node of Minos