### PR TITLE
Fix deadlock and memory leak issue for minos

### DIFF
--- a/core/mbox.c
+++ b/core/mbox.c
@@ -99,12 +99,6 @@ static int __mbox_post_opt(mbox_t *m, void *pmsg, int pend_state, int opt)
 	 */
 	spin_lock_irqsave(&m->lock, flags);
 	ret = wake_up_event_waiter(TO_EVENT(m), pmsg, pend_state, opt);
-	if (!ret) {
-		if (m->data != NULL)
-			ret = -ENOSPC;
-		else
-			m->data = pmsg;
-	}
 	spin_unlock_irqrestore(&m->lock, flags);
 
 	if (ret)

--- a/core/sched.c
+++ b/core/sched.c
@@ -612,9 +612,11 @@ static int wake_up_common(struct task *task, long pend_state, int event, void *d
 	if (event == OS_EVENT_TYPE_FLAG) {
 		task->flags_rdy = (long)data;
 		task->msg = NULL;
+		spin_unlock_irqrestore(&task->s_lock, flags);
 	} else {
 		task->msg = data;
 		task->flags_rdy = 0;
+		spin_unlock_irqrestore(&task->s_lock, flags);
 	}
 
 	spin_unlock_irqrestore(&task->s_lock, flags);

--- a/virt/hypercall.c
+++ b/virt/hypercall.c
@@ -98,6 +98,9 @@ static int vm_hvc_handler(gp_regs *c, uint32_t id, uint64_t *args)
 	case HVC_CHANGE_LOG_LEVEL:
 		change_log_level((unsigned int)args[0]);
 		break;
+	case HVC_DUMP_LOG:
+		dump_system_log();
+		break;
 	default:
 		pr_err("unsupport vm hypercall");
 		break;


### PR DESCRIPTION
1 - memory leak issue was fix in mbox.c
2 - deadlock issue fix in sched.c